### PR TITLE
python 3.10+ compatibillity (MutableMapping, VACUUM)

### DIFF
--- a/sqlite_dbm.py
+++ b/sqlite_dbm.py
@@ -43,10 +43,13 @@ import sqlite3
 try:
     from UserDict import DictMixin
 except ImportError:
-    from collections import MutableMapping as DictMixin
+    try:
+        from collections import MutableMapping as DictMixin
+    except ImportError:
+        # https://stackoverflow.com/questions/70870041/cannot-import-name-mutablemapping-from-collections/70870131#70870131
+        from collections.abc import MutableMapping as DictMixin
 
-
-__version__ = '3.2.0'
+__version__ = '3.2.1'
 
 if sys.version_info < (3, ):
     pickle_loads = pickle.loads
@@ -103,6 +106,8 @@ class SQLiteDBM(DictMixin):
         self.conn.commit()
 
     def close(self):
+        # https://github.com/ghaering/pysqlite/issues/109
+        self.conn.isolation_level = None
         self.conn.execute("VACUUM")
         self.conn.close()
 


### PR DESCRIPTION
Hi, I fixed two small errors
- MutableMapping has (again?) changed place in python 3.10, and
- "cannot VACUUM inside transaction"


More precisely, the errors are:

-
  ```python3
      ...
    File "/tmp/pip-install-92z2kio4/sqlite-dbm_6ca5c06ce36e45b2a8356208f384c191/sqlite_dbm.py", line 46, in <module>
      from collections import MutableMapping as DictMixin
  ImportError: cannot import name 'MutableMapping' from 'collections' (/usr/lib/python3.10/collections/__init__.py)
  ```
  which happens on trying to install the package via pip.

-
  ```python3
      ...
    File ".../sqlite_dbm/sqlite_dbm.py", line 108, in close
      self.conn.execute("VACUUM")
  sqlite3.OperationalError: cannot VACUUM from within a transaction
  ```
  which happens when closing a database, for example when trying to run the doctests :)


I fixed the errors
- by having another import in a try/except for 3.10+ as https://stackoverflow.com/questions/70870041/cannot-import-name-mutablemapping-from-collections/70870131#70870131 says, and
- by lifting the isolation level temporarily just for the VACUUM before closing https://github.com/ghaering/pysqlite/issues/109 ...

Would be great if the fixes landed in [pypi](https://pypi.org/project/sqlite_dbm/) eventually :)

Best, David